### PR TITLE
Update gold-standard.md

### DIFF
--- a/help/rn/using/gold-standard.md
+++ b/help/rn/using/gold-standard.md
@@ -26,7 +26,7 @@ _22 December 2020_
 >
 >This release comes with a new connection protocol: upgrade is mandatory for both Campaign server and client console to be able to connect to Campaign after March 21st, 2021.
 
-The build 9032&#64;2a2a028 includes the following improvements and fixes:
+The build 9032&#64;d3b452f includes the following improvements and fixes:
 
 * The connection protocol has been updated to follow the new IMS authentication mechanism. 
 


### PR DESCRIPTION
Replaced with the GS11 build code "9032@2a2a028" with "9032@d3b452f", as that's what currently displayed after installation.
Tested with GS11 client console (Help > About), and GS11 Win64 binary (nlserver pdump). Not tested on Linux binaries.
Please do double-check and update.
Hope this is helpful!  (please do leave me a comment/acknowledgement if so)